### PR TITLE
Fix incorrect cbj_hub link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 This repository is in charge of the CyBear Jinni App and is part of the [CyBear Jinni Smart Home](https://github.com/CyBear-Jinni/CBJ_Smart-Home.git) system.
 
-The CyBear Jinni App lets you control the [CyBear Jinni Hub](https://github.com/CyBear-Jinni/CBJ_Smart-Device) that manage the smart devices from different vendors.
+The CyBear Jinni App lets you control the [CyBear Jinni Hub](https://github.com/CyBear-Jinni/cbj_hub) that manage the smart devices from different vendors.
 
 
 It is writen with [Flutter](https://flutter.dev) and let you control the CyBear Jinni Hub directly in the local Wi-Fi and remotely through [cbj remote pipes](https://github.com/CyBear-Jinni/cbj_remote-pipes) which transfer requests to the Hub without collecting any data.
@@ -22,7 +22,7 @@ It is writen with [Flutter](https://flutter.dev) and let you control the CyBear 
 
 <table align="middle">
   <tr>
-    <td> 
+    <td>
       <p>
          <a href="https://play.google.com/store/apps/details?id=com.cybear_jinni.smart_home">
          <img border="0" align="middle" alt="Android Badge" src="https://user-images.githubusercontent.com/9304740/117003444-8b58a080-aced-11eb-94bc-bfb2505f515d.png" width=200>


### PR DESCRIPTION
Fixed incorrect cbj_hub link in README.md with correct link:
https://github.com/CyBear-Jinni/cbj_hub

Closes #473 