### PR TITLE
:bricks: ci: ignore `injection.config.dart` file

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
 
       - name: Perform formatting
-        run: find . -name "*.dart" ! -path '*/gen/*' | tr '\n' ' ' | xargs dart format
+        run: find . -name "*.dart" ! -path '*/gen/*' ! -name 'injection.config.dart' | tr '\n' ' ' | xargs dart format
 
       # Perform the commit at the end to make sure tests above don't fail
       - name: Commit formatting changes


### PR DESCRIPTION
Closes #534 